### PR TITLE
Support gsplit for OS X, Update Readme #11

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ zbarimg --version
 You can download and build zbar from [github.com/mchehab/zbar/](https://github.com/mchehab/zbar/).
 Note that zbar is **not** required for `paperify.sh` It is only required for `digitallify.sh` decoding.
 
+### Mac OS X
+
+To install the requirements you can use Homebrew.
+
+```
+brew install coreutils qrencode zbarimg
+```
+
 ## Installation
 
 These are just bash scripts. There is no need to install them.
@@ -51,6 +59,7 @@ Or you can use paperify's Docker image at alisinabh/paperify. More details below
 # scanned pages inside. Make sure the file namings are correct 
 ./digitalify.sh OUTPUT_FILE DIRECTORY
 ```
+
 
 ### Use with Docker
 

--- a/paperify.sh
+++ b/paperify.sh
@@ -38,7 +38,15 @@ echo $(pwd)
 sha=$(sha1sum "$file" | cut -f 1 -d ' ')
 date=$(date -u +%Y-%m-%dT%H:%M:%S+00:00)
 
-cat "$file" | split -d -b 2953 -a3 - "$dir/$prefix"
+SPLIT_BIN=split
+
+if [[ $OSTYPE == "darwin"* ]]; then
+	# Use gsplit in OS X as split does not support -d 
+	# Issue #11
+	SPLIT_BIN=gsplit
+fi
+
+eval "cat \"$file\" | $SPLIT_BIN -d -b 2953 -a3 - \"$dir/$prefix\""
 
 cd "$dir"
 


### PR DESCRIPTION
Closes #11 

 - [x] Use gsplit in darwin (OS X)
 - [x] Update requirements in `README.md` for OS X with brew.