### PR TITLE
Downgrade CI to ubuntu-20.04

### DIFF
--- a/.github/workflows/paperify_ci.yaml
+++ b/.github/workflows/paperify_ci.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   test:
     name: Test paperify
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       FONT: Roboto
       IMG_HELP_MESSAGE: "UNPACK: zbarimg --raw -Sbinary -1 FILENAME.jpg | head -c 2953 > paperify.tgz"

--- a/.github/workflows/paperify_package.yaml
+++ b/.github/workflows/paperify_package.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   test:
     name: Make paperify printable asset
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       FONT: Roboto
       IMG_HELP_MESSAGE: "UNPACK: zbarimg --raw -Sbinary -1 FILENAME.jpg | head -c 2953 > paperify.tgz"


### PR DESCRIPTION
ubuntu-latest is now 22.04 which breaks the zbar dependency in CI. This is only a temporary fix until the CI script is compatible with newer version of ubuntu.